### PR TITLE
feature/3

### DIFF
--- a/LotComWatcher/Models/Datasources/EventRouter.cs
+++ b/LotComWatcher/Models/Datasources/EventRouter.cs
@@ -1,4 +1,5 @@
 using LotComWatcher.Models.Datatypes;
+using LotComWatcher.Models.Services;
 
 namespace LotComWatcher.Models.Datasources;
 
@@ -13,14 +14,20 @@ public static class EventRouter
         {
             // Creating TablePath that points us to the correct folder which is the process name. 
             string TablePath = $"{ScanFolder}\\{ScanEvent.Label.Process.FullName}.txt";
-            // Creating newEntry which is taking the ScanEvent and formatting it for us through the CSV methods. 
-            string newEntry = ScanEvent.ToCSV();
             // Creating an array that is reading all the lines through the TablePath file.
             IEnumerable<string> Lines = File.ReadAllLines(TablePath);
             // Adding the most recent entry to the bottom of our file.
-            Lines = Lines.Append(newEntry);
-            // Saving our changes 
-            File.WriteAllLines(TablePath, Lines);
+            if (ScanEventInsertionService.ValidateInsertion(ScanEvent, Lines))
+            {
+                string newEntry = ScanEvent.ToCSV();
+                Lines = Lines.Append(newEntry);
+                File.WriteAllLines(TablePath, Lines);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
         // there was an error routing
         catch
@@ -32,6 +39,3 @@ public static class EventRouter
         return true;
     }
 }
-
-
-

--- a/LotComWatcher/Models/Datasources/EventRouter.cs
+++ b/LotComWatcher/Models/Datasources/EventRouter.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using LotComWatcher.Models.Datatypes;
 
 namespace LotComWatcher.Models.Datasources;
@@ -10,9 +9,27 @@ public static class EventRouter
 
     public static bool Route(ScanEvent ScanEvent)
     {
-        string TablePath = $"{ScanFolder}\\{ScanEvent.Label.Process.FullName}";
-        Console.WriteLine(TablePath);
-        return false;
+        try
+        {
+            // Creating TablePath that points us to the correct folder which is the process name. 
+            string TablePath = $"{ScanFolder}\\{ScanEvent.Label.Process.FullName}.txt";
+            // Creating newEntry which is taking the ScanEvent and formatting it for us through the CSV methods. 
+            string newEntry = ScanEvent.ToCSV();
+            // Creating an array that is reading all the lines through the TablePath file.
+            IEnumerable<string> Lines = File.ReadAllLines(TablePath);
+            // Adding the most recent entry to the bottom of our file.
+            Lines = Lines.Append(newEntry);
+            // Saving our changes 
+            File.WriteAllLines(TablePath, Lines);
+        }
+        // there was an error routing
+        catch
+        {
+            Console.WriteLine($"Could not route ScanEvent: {ScanEvent.ToCSV()}");
+            return false;
+        }
+        // succeeded in routing; return true
+        return true;
     }
 }
 

--- a/LotComWatcher/Models/Datasources/EventRouter.cs
+++ b/LotComWatcher/Models/Datasources/EventRouter.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics;
+using LotComWatcher.Models.Datatypes;
+
+namespace LotComWatcher.Models.Datasources;
+
+
+public static class EventRouter
+{
+    private static string ScanFolder = "\\\\144.133.122.1\\Lot Control Management\\Database\\data_tables\\scans";
+
+    public static bool Route(ScanEvent ScanEvent)
+    {
+        string TablePath = $"{ScanFolder}\\{ScanEvent.Label.Process.FullName}";
+        Console.WriteLine(TablePath);
+        return false;
+    }
+}
+
+
+

--- a/LotComWatcher/Models/Datasources/EventRouter.cs
+++ b/LotComWatcher/Models/Datasources/EventRouter.cs
@@ -85,10 +85,14 @@ public static class EventRouter
         }
         // elicit the Serial Number from the new Scan Event
         SerialNumber EventNumber = GetSerialNumber(ScanEvent);
-        // check for previous process scan entry
-        if (!ScanEventInsertionService.ValidatePreviousProcess(ScanEvent, EventNumber))
+        // check for a match in the Previous Process scans Datatable (only if configured for the ScanEvent's Process)
+        string? PreviousProcess = ScanEvent.Label.Process.PreviousProcesses[0];
+        if (PreviousProcess is not null && !PreviousProcess.Equals(""))
         {
-            return "No Scan Entry found in previous Process; insertion blocked.";
+            if (!ScanEventInsertionService.ValidatePreviousProcess(ScanEvent, EventNumber))
+            {
+                return "No Scan Entry found in previous Process; insertion blocked.";
+            }
         }
         // Adding the most recent entry to the bottom of our file.
         if (ScanEventInsertionService.ValidateDuplicateScan(ScanEvent, EventNumber, DatabaseSet))

--- a/LotComWatcher/Models/Datasources/EventRouter.cs
+++ b/LotComWatcher/Models/Datasources/EventRouter.cs
@@ -1,6 +1,7 @@
 using LotCom.Enums;
 using LotCom.Types;
 using LotComWatcher.Models.Datatypes;
+using LotComWatcher.Models.Enums;
 using LotComWatcher.Models.Exceptions;
 using LotComWatcher.Models.Services;
 
@@ -57,7 +58,7 @@ public static class EventRouter
     /// </summary>
     /// <param name="ScanEvent"></param>
     /// <returns></returns>
-    public static string Route(ScanEvent ScanEvent)
+    public static InsertionMessage Route(ScanEvent ScanEvent)
     {
         // prepare the Table and DatabaseSet
         string TablePath = "";
@@ -91,7 +92,7 @@ public static class EventRouter
         {
             if (!ScanEventInsertionService.ValidatePreviousProcess(ScanEvent, EventNumber))
             {
-                return "No Scan Entry found in previous Process; insertion blocked.";
+                return InsertionMessage.MissingPrevious;
             }
         }
         // Adding the most recent entry to the bottom of our file.
@@ -102,11 +103,11 @@ public static class EventRouter
             DatabaseSet = DatabaseSet.Append(newEntry);
             // save the file with the new entry appended
             File.WriteAllLines(TablePath, DatabaseSet);
-            return "Valid Scan Event; Successfully inserted.";
+            return InsertionMessage.ValidEntry;
         }
         else
         {
-            return "Duplicate Scan Event; insertion blocked.";
+            return InsertionMessage.DuplicateScan;
         }
     }
 }

--- a/LotComWatcher/Models/Datasources/EventRouter.cs
+++ b/LotComWatcher/Models/Datasources/EventRouter.cs
@@ -1,41 +1,63 @@
 using LotComWatcher.Models.Datatypes;
+using LotComWatcher.Models.Exceptions;
 using LotComWatcher.Models.Services;
 
 namespace LotComWatcher.Models.Datasources;
 
-
+/// <summary>
+/// Provides database insertion and routing methods for ScanEvent objects.
+/// </summary>
 public static class EventRouter
 {
-    private static string ScanFolder = "\\\\144.133.122.1\\Lot Control Management\\Database\\data_tables\\scans";
+    /// <summary>
+    /// URI for the "scans" section of the Database, where each Process' scan datatable lives.
+    /// </summary>
+    private static readonly string ScanFolder = "\\\\144.133.122.1\\Lot Control Management\\Database\\data_tables\\scans";
 
+    /// <summary>
+    /// Attempts to route and insert ScanEvent into its appropriate Process datatable.
+    /// </summary>
+    /// <param name="ScanEvent"></param>
+    /// <returns></returns>
     public static bool Route(ScanEvent ScanEvent)
     {
+        // prepare the Table and DatabaseSet
+        string TablePath = "";
+        IEnumerable<string> DatabaseSet; // was Lines
         try
         {
             // Creating TablePath that points us to the correct folder which is the process name. 
-            string TablePath = $"{ScanFolder}\\{ScanEvent.Label.Process.FullName}.txt";
+            TablePath = $"{ScanFolder}\\{ScanEvent.Label.Process.FullName}.txt";
             // Creating an array that is reading all the lines through the TablePath file.
-            IEnumerable<string> Lines = File.ReadAllLines(TablePath);
-            // Adding the most recent entry to the bottom of our file.
-            if (ScanEventInsertionService.ValidateInsertion(ScanEvent, Lines))
-            {
-                string newEntry = ScanEvent.ToCSV();
-                Lines = Lines.Append(newEntry);
-                File.WriteAllLines(TablePath, Lines);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            DatabaseSet = File.ReadAllLines(TablePath);
         }
-        // there was an error routing
-        catch
+        // the file could not be found by the Router
+        catch (FileNotFoundException)
         {
-            Console.WriteLine($"Could not route ScanEvent: {ScanEvent.ToCSV()}");
+            throw new ProcessNameException($"Could not find a table for the Process '{ScanEvent.Label.Process.FullName}'.");
+        }
+        // there was another issue accessing the file
+        catch (SystemException _ex)
+        {
+            throw new DatabaseException
+            (
+                Message: $"Failed to open the file at '{TablePath}' due to the following exception:\n{_ex.Message}.",
+                InnerException: _ex
+            );
+        }
+        // Adding the most recent entry to the bottom of our file.
+        if (ScanEventInsertionService.ValidateInsertion(ScanEvent, DatabaseSet))
+        {
+            // convert the ScanEvent to a string and append it to the end of the DatabaseSet
+            string newEntry = ScanEvent.ToCSV();
+            DatabaseSet = DatabaseSet.Append(newEntry);
+            // save the file with the new entry appended
+            File.WriteAllLines(TablePath, DatabaseSet);
+            return true;
+        }
+        else
+        {
             return false;
         }
-        // succeeded in routing; return true
-        return true;
     }
 }

--- a/LotComWatcher/Models/Datatypes/ScanEvent.cs
+++ b/LotComWatcher/Models/Datatypes/ScanEvent.cs
@@ -100,7 +100,7 @@ public sealed class ScanEvent
             ProductionDate,
             ProductionShift,
             ProductionOperator
-        );            
+        );
     }
 
     /// <summary>
@@ -250,5 +250,11 @@ public sealed class ScanEvent
         {
             throw;
         }
+    }
+    public string ToCSV()
+    {
+        string CSVLine = $"{Label.Process},{new Timestamp(Date).Stamp},{Address},{Label.Part.ToCSV()},{Label.Quantity},{Label.VariableFields.ToCSV()},{new Timestamp(Label.ProductionDate).Stamp},{ShiftExtensions.ToString(Label.ProductionShift)},{Label.ProductionOperator}";
+
+        return CSVLine;
     }
 }

--- a/LotComWatcher/Models/Enums/InsertionMessage.cs
+++ b/LotComWatcher/Models/Enums/InsertionMessage.cs
@@ -1,0 +1,8 @@
+namespace LotComWatcher.Models.Enums;
+
+ public enum InsertionMessage
+{
+    DuplicateScan,
+    MissingPrevious,
+    ValidEntry
+}

--- a/LotComWatcher/Models/Exceptions/DatabaseException.cs
+++ b/LotComWatcher/Models/Exceptions/DatabaseException.cs
@@ -1,0 +1,10 @@
+namespace LotComWatcher.Models.Exceptions;
+
+/// <summary>
+/// Special exception type to indicate an error interfacing with the Database.
+/// </summary>
+/// <param name="Message"></param>
+public class DatabaseException(string Message, Exception? InnerException = null) : Exception(message: Message, innerException: InnerException)
+{
+
+}

--- a/LotComWatcher/Models/Exceptions/InsertionException.cs
+++ b/LotComWatcher/Models/Exceptions/InsertionException.cs
@@ -1,0 +1,10 @@
+namespace LotComWatcher.Models.Exceptions;
+
+/// <summary>
+/// Special exception type to indicate an error adding an entry to a Table within the Database.
+/// </summary>
+/// <param name="Message"></param>
+public class InsertionException(string Message, Exception? InnerException = null) : DatabaseException(Message: Message, InnerException: InnerException)
+{
+
+}

--- a/LotComWatcher/Models/Exceptions/ProcessNameException.cs
+++ b/LotComWatcher/Models/Exceptions/ProcessNameException.cs
@@ -1,0 +1,10 @@
+namespace LotComWatcher.Models.Exceptions;
+
+/// <summary>
+/// Indicates an error referencing an undefined Process name that is not null.
+/// </summary>
+/// <param name="Message"></param>
+public sealed class ProcessNameException(string Message) : Exception(message: Message)
+{
+
+}

--- a/LotComWatcher/Models/Services/FailedScanService.cs
+++ b/LotComWatcher/Models/Services/FailedScanService.cs
@@ -1,0 +1,35 @@
+namespace LotComWatcher.Models.Services;
+
+public sealed class FailedScanService
+{
+    /// <summary>
+    /// The failed scan log file that contains information regarding failed scan events from LotCom Scanners.
+    /// </summary>
+    private readonly string OutputFile = @"\\144.133.122.1\Lot Control Management\Database\logs\failed_scans.log";
+
+    /// <summary>
+    /// Logs a failure to process a Scan string RawEvent due to an unexpected exception Cause.
+    /// </summary>
+    /// <param name="RawEvent"></param>
+    /// <param name="Cause"></param>
+    /// <returns>The success status of the Log attempt.</returns>
+    public static bool LogFailedScanEvent(string RawEvent, Exception Cause)
+    {
+        string Log =
+            $"[{DateTime.Now}] Could not process '{RawEvent}'." +
+            $"\n\tException:" +
+            $"\n\t\tType: {Cause.GetType()}" +
+            $"\n\t\tMessage: {Cause.Message}" +
+            $"\n\t\tTrace: {Cause.StackTrace}";
+        // write to the failed scans log file
+        try
+        {
+            Console.WriteLine(Log);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    } 
+}

--- a/LotComWatcher/Models/Services/FailedScanService.cs
+++ b/LotComWatcher/Models/Services/FailedScanService.cs
@@ -1,11 +1,11 @@
 namespace LotComWatcher.Models.Services;
 
-public sealed class FailedScanService
+public static class FailedScanService
 {
     /// <summary>
     /// The failed scan log file that contains information regarding failed scan events from LotCom Scanners.
     /// </summary>
-    private readonly string OutputFile = @"\\144.133.122.1\Lot Control Management\Database\logs\failed_scans.log";
+    private const string LogFile = @"\\144.133.122.1\Lot Control Management\Database\logs\failed_scans.log";
 
     /// <summary>
     /// Logs a failure to process a Scan string RawEvent due to an unexpected exception Cause.
@@ -13,7 +13,7 @@ public sealed class FailedScanService
     /// <param name="RawEvent"></param>
     /// <param name="Cause"></param>
     /// <returns>The success status of the Log attempt.</returns>
-    public static bool LogFailedScanEvent(string RawEvent, Exception Cause)
+    public static async Task LogFailedScanEvent(string RawEvent, Exception Cause)
     {
         string Log =
             $"[{DateTime.Now}] Could not process '{RawEvent}'." +
@@ -25,11 +25,12 @@ public sealed class FailedScanService
         try
         {
             Console.WriteLine(Log);
-            return true;
+            await File.WriteAllTextAsync(LogFile, $"{Log}\n--------------------\n");
         }
         catch
         {
-            return false;
+            Console.WriteLine("Failed to log the following failed scan string:");
+            Console.WriteLine(Log);
         }
     } 
 }

--- a/LotComWatcher/Models/Services/ReaderService.cs
+++ b/LotComWatcher/Models/Services/ReaderService.cs
@@ -14,7 +14,7 @@ public sealed class ReaderService
     /// </summary>
     /// <returns>A List of Scan results as strings.</returns>
     /// <exception cref="OutputFileAccessException"></exception>
-    public async Task<string[]> Read()
+    public async Task<List<string>> Read()
     {
         // attempt to read the Scan Output file and throw an access exception if the read fails
         try
@@ -22,7 +22,7 @@ public sealed class ReaderService
             // save the Raw Scans from the file, clear its contents, and return the Scans
             string[] RawScans = await File.ReadAllLinesAsync(OutputFile);
             await File.WriteAllTextAsync(OutputFile, "");
-            return RawScans;
+            return RawScans.ToList();
         }
         catch (OperationCanceledException _ex)
         {

--- a/LotComWatcher/Models/Services/ReaderService.cs
+++ b/LotComWatcher/Models/Services/ReaderService.cs
@@ -1,6 +1,6 @@
 using LotComWatcher.Models.Exceptions;
 
-namespace LotComWatcher;
+namespace LotComWatcher.Models.Services;
 
 public sealed class ReaderService
 {

--- a/LotComWatcher/Models/Services/ScanEventInsertionService.cs
+++ b/LotComWatcher/Models/Services/ScanEventInsertionService.cs
@@ -10,27 +10,55 @@ namespace LotComWatcher.Models.Services;
 public static class ScanEventInsertionService
 {
     /// <summary>
+    /// Attempts to retrieve and construct a SerialNumber object from ScanEvent.
+    /// </summary>
+    /// <param name="Event"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentException"></exception>
+    private static SerialNumber GetSerialNumber(ScanEvent Event)
+    {
+        SerialNumber EventNumber;
+        Process EventProcess = Event.Label.Process;
+        // ScanEvent uses a JBK Number
+        if
+        (
+            EventProcess.PassThroughType == PassThroughType.JBK ||
+            EventProcess.Serialization == SerializationMode.JBK
+        )
+        {
+            EventNumber = new SerialNumber(SerializationMode.JBK, Event.Label.Part, Event.Label.VariableFields.JBKNumber!.Literal);
+        }
+        // ScanEvent uses a Lot Number
+        else if
+        (
+            EventProcess.PassThroughType == PassThroughType.Lot ||
+            EventProcess.Serialization == SerializationMode.Lot
+        )
+        {
+            EventNumber = new SerialNumber(SerializationMode.Lot, Event.Label.Part, Event.Label.VariableFields.LotNumber!.Literal);
+        }
+        // some mis-configuration of SerializationMode and PassThroughType caused an error
+        else
+        {
+            throw new ArgumentException($"Cannot retrieve a SerialNumber from the ScanEvent '{Event.ToCSV()}'.");
+        }
+        return EventNumber;
+    }
+
+    /// <summary>
     /// Compares a ScanEvent object's serial data to a raw Database Entry's serial data.
     /// </summary>
     /// <param name="Event"></param>
+    /// <param name="EventNumber"></param>
     /// <param name="Entry"></param>
     /// <returns></returns>
-    private static bool Compare(ScanEvent Event, string Entry)
+    private static bool Compare(ScanEvent Event, SerialNumber EventNumber, string Entry)
     {
         // split Entry to its individual fields and compare to Event's Serial data
         string[] SplitEntry = Entry.Split(",");
         string EntryPartNumber = SplitEntry[3];
         string EntrySerialNumber = SplitEntry[6];
         string EntryDate = SplitEntry[^3];
-        SerialNumber EventNumber;
-        if (Event.Label.Process.Serialization == SerializationMode.JBK)
-        {
-            EventNumber = new SerialNumber(SerializationMode.JBK, Event.Label.Part, Event.Label.VariableFields.JBKNumber!.Literal);
-        }
-        else
-        {
-            EventNumber = new SerialNumber(SerializationMode.Lot, Event.Label.Part, Event.Label.VariableFields.LotNumber!.Literal);
-        }
         // compare the SerialNumbers and Dates
         if
         (
@@ -53,9 +81,12 @@ public static class ScanEventInsertionService
     /// <returns></returns>
     public static bool ValidateInsertion(ScanEvent NewEvent, IEnumerable<string> DatabaseSet)
     {
+        Console.WriteLine(NewEvent.ToCSV());
+        // elicit the Serial Number from the new Scan Event
+        SerialNumber EventNumber = GetSerialNumber(NewEvent);
         // compare the ScanEvent data to each of the DatabaseSet entries
         List<string> Matches = DatabaseSet
-            .Where(x => Compare(NewEvent, x) == true)
+            .Where(x => Compare(NewEvent, EventNumber, x))
             .ToList();
         if (Matches.Count > 0)
         {

--- a/LotComWatcher/Models/Services/ScanEventInsertionService.cs
+++ b/LotComWatcher/Models/Services/ScanEventInsertionService.cs
@@ -99,14 +99,14 @@ public static class ScanEventInsertionService
         try
         {
             // Creating TablePath that points us to the correct folder which is the process name. 
-            TablePath = $"{ScanFolder}\\{NewEvent.Label.Process.PreviousProcesses[0]!.FullName}.txt";
+            TablePath = $"{ScanFolder}\\{NewEvent.Label.Process.PreviousProcesses[0]}.txt";
             // Creating an array that is reading all the lines through the TablePath file.
             DatabaseSet = File.ReadAllLines(TablePath);
         }
         // the file could not be found by the Router
         catch (FileNotFoundException)
         {
-            throw new ProcessNameException($"Could not find a table for the Process '{NewEvent.Label.Process.PreviousProcesses[0]!.FullName}'.");
+            throw new ProcessNameException($"Could not find a table for the Process '{NewEvent.Label.Process.PreviousProcesses[0]}'.");
         }
         // there was another issue accessing the file
         catch (SystemException _ex)

--- a/LotComWatcher/Models/Services/ScanEventInsertionService.cs
+++ b/LotComWatcher/Models/Services/ScanEventInsertionService.cs
@@ -1,0 +1,74 @@
+using LotCom.Enums;
+using LotCom.Types;
+using LotComWatcher.Models.Datatypes;
+
+namespace LotComWatcher.Models.Services;
+
+/// <summary>
+/// Provides insertion validation methods for ScanEvent objects.
+/// </summary>
+public static class ScanEventInsertionService
+{
+    /// <summary>
+    /// Compares a ScanEvent object's serial data to a raw Database Entry's serial data.
+    /// </summary>
+    /// <param name="Event"></param>
+    /// <param name="Entry"></param>
+    /// <returns></returns>
+    private static bool Compare(ScanEvent Event, string Entry)
+    {
+        // split Entry to its individual fields and compare to Event's Serial data
+        string[] SplitEntry = Entry.Split(",");
+        string EntryPartNumber = SplitEntry[3];
+        string EntrySerialNumber = SplitEntry[6];
+        string EntryDate = SplitEntry[^3];
+        SerialNumber EventNumber;
+        if (Event.Label.Process.Serialization == SerializationMode.JBK)
+        {
+            EventNumber = new SerialNumber(SerializationMode.JBK, Event.Label.Part, Event.Label.VariableFields.JBKNumber!.Literal);
+        }
+        else
+        {
+            EventNumber = new SerialNumber(SerializationMode.Lot, Event.Label.Part, Event.Label.VariableFields.LotNumber!.Literal);
+        }
+        // compare the SerialNumbers and Dates
+        if
+        (
+            EventNumber.GetFormattedValue().Equals(EntrySerialNumber) &&
+            EventNumber.Part.PartNumber.Equals(EntryPartNumber) &&
+            new Timestamp(Event.Label.ProductionDate).Stamp.Equals(EntryDate)
+        )
+        {
+            return true;
+        }
+        // comparison does not match
+        return false;
+    }
+
+    /// <summary>
+    /// Checks if NewEvent object is unique within the passed set of Database entries. 
+    /// </summary>
+    /// <param name="NewEvent"></param>
+    /// <param name="DatabaseSet"></param>
+    /// <returns></returns>
+    public static bool ValidateInsertion(ScanEvent NewEvent, IEnumerable<string> DatabaseSet)
+    {
+        // compare the ScanEvent data to each of the DatabaseSet entries
+        List<string> Matches = DatabaseSet
+            .Where(x => Compare(NewEvent, x) == true)
+            .ToList();
+        if (Matches.Count > 0)
+        {
+            Console.WriteLine($"Matches for\n {NewEvent.ToCSV()}:");
+            foreach (string _match in Matches)
+            {
+                Console.WriteLine(_match);
+            }
+            return false;
+        }
+        else
+        {
+            return true;
+        }
+    }
+}

--- a/LotComWatcher/Program.cs
+++ b/LotComWatcher/Program.cs
@@ -1,4 +1,5 @@
 using LotComWatcher;
+using LotComWatcher.Models.Services;
 
 var builder = Host.CreateApplicationBuilder(args);
 // set the service name

--- a/LotComWatcher/ReaderService.cs
+++ b/LotComWatcher/ReaderService.cs
@@ -19,7 +19,10 @@ public sealed class ReaderService
         // attempt to read the Scan Output file and throw an access exception if the read fails
         try
         {
-            return await File.ReadAllLinesAsync(OutputFile);
+            // save the Raw Scans from the file, clear its contents, and return the Scans
+            string[] RawScans = await File.ReadAllLinesAsync(OutputFile);
+            await File.WriteAllTextAsync(OutputFile, "");
+            return RawScans;
         }
         catch (OperationCanceledException _ex)
         {

--- a/LotComWatcher/Worker.cs
+++ b/LotComWatcher/Worker.cs
@@ -35,7 +35,7 @@ public class Worker : BackgroundService
                 ScanEvent[] ParseResults = await Task.WhenAll(ParseTasks);
                 if (ParseResults is null)
                 {
-                    Console.WriteLine("No new Scan Events.");
+                    Logger.LogInformation("No new Scan Events.");
                 }
                 else
                 {
@@ -44,7 +44,11 @@ public class Worker : BackgroundService
                     {
                         if (EventRouter.Route(_event))
                         {
-                            Console.WriteLine("Routed successfully.");
+                            Logger.LogInformation("Unique Scan; inserted successfully.");
+                        }
+                        else
+                        {
+                            Logger.LogWarning("Duplicate Scan; insertion blocked.");
                         }
                     }
                 }

--- a/LotComWatcher/Worker.cs
+++ b/LotComWatcher/Worker.cs
@@ -1,5 +1,6 @@
 using LotComWatcher.Models.Datasources;
 using LotComWatcher.Models.Datatypes;
+using LotComWatcher.Models.Enums;
 
 namespace LotComWatcher;
 
@@ -42,8 +43,20 @@ public class Worker : BackgroundService
                     // Route ScanEvents
                     foreach (ScanEvent _event in ParseResults)
                     {
-                        string Message = EventRouter.Route(_event);
-                        Logger.LogInformation(Message);
+                        Models.Enums.InsertionMessage Message = EventRouter.Route(_event);
+                        // Logger.LogInformation(Message);
+                        if (Message == InsertionMessage.MissingPrevious)
+                        {
+                            Console.WriteLine("Missing Previous Process");
+                        }
+                        else if (Message == InsertionMessage.DuplicateScan)
+                        {
+                            Console.WriteLine("Duplicate Scan");
+                        }
+                        else
+                        {
+                            Console.WriteLine("Valid Entry");
+                        }
                     }
                 }
                 await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);

--- a/LotComWatcher/Worker.cs
+++ b/LotComWatcher/Worker.cs
@@ -42,14 +42,8 @@ public class Worker : BackgroundService
                     // Route ScanEvents
                     foreach (ScanEvent _event in ParseResults)
                     {
-                        if (EventRouter.Route(_event))
-                        {
-                            Logger.LogInformation("Unique Scan; inserted successfully.");
-                        }
-                        else
-                        {
-                            Logger.LogWarning("Duplicate Scan; insertion blocked.");
-                        }
+                        string Message = EventRouter.Route(_event);
+                        Logger.LogInformation(Message);
                     }
                 }
                 await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);

--- a/LotComWatcher/Worker.cs
+++ b/LotComWatcher/Worker.cs
@@ -1,6 +1,7 @@
 using LotComWatcher.Models.Datasources;
 using LotComWatcher.Models.Datatypes;
 using LotComWatcher.Models.Enums;
+using LotComWatcher.Models.Services;
 
 namespace LotComWatcher;
 

--- a/LotComWatcher/Worker.cs
+++ b/LotComWatcher/Worker.cs
@@ -1,3 +1,4 @@
+using LotComWatcher.Models.Datasources;
 using LotComWatcher.Models.Datatypes;
 
 namespace LotComWatcher;
@@ -32,9 +33,17 @@ public class Worker : BackgroundService
                     .Select(ScanEvent.ParseCSV)
                     .ToList();
                 ScanEvent[] ParseResults = await Task.WhenAll(ParseTasks);
-                if (ParseResults is null) 
+                if (ParseResults is null)
                 {
                     Console.WriteLine("No new Scan Events.");
+                }
+                else
+                {
+                    // Route ScanEvents
+                    foreach (ScanEvent _event in ParseResults)
+                    {
+                        EventRouter.Route(_event);
+                    }
                 }
                 await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
             }

--- a/LotComWatcher/Worker.cs
+++ b/LotComWatcher/Worker.cs
@@ -42,7 +42,10 @@ public class Worker : BackgroundService
                     // Route ScanEvents
                     foreach (ScanEvent _event in ParseResults)
                     {
-                        EventRouter.Route(_event);
+                        if (EventRouter.Route(_event))
+                        {
+                            Console.WriteLine("Routed successfully.");
+                        }
                     }
                 }
                 await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);


### PR DESCRIPTION
# feature/3

## Addressed Feature Request
Resolves #3  

## Summary

**Briefly describe the feature being introduced.**

Routing support has been implemented, completing the initial functionality of the **LotCom Watcher** service.

## Rationale

**Explain the reasoning behind this feature and its benefits to the project.**

Routing of Scanner output from the bulk output file to Process tables is a key function of the **LotCom Database**. Without this automated routing, there would be manual work required to sort and organize these outputs into a useful system.

## Changes

**List the major changes made in this pull request.**

#### `ScanEvent.cs`:
- Add `ToCSV()` method:
  - Provides consistent conversion to a CSV line that follows the formatting of the Database.

#### `ReaderService.cs`:
- Refactor `Read()` method:
  - Remove the text in the Scan output file to avoid constantly parsing the same output infinitely.

#### `Worker.cs`:
- Add `ClearFaultingParses()` method:
  - Creates more resilience in the routing process by avoiding the invocation of faulty parses;
  - Logs faulting tasks to the Database in a failed scans log file.
- Refactor `ExecuteAsync()` method:
  - Implement Scan output reading, output parsing, and parsed event routing (major functionality).

## New classes

**List any new classes or members implemented in this pull request.**

#### `InsertionMessage.cs`:
Enumerable providing the possible insertion outcomes from `ScanEventInsertionService` class.

#### `DatabaseException.cs`, `InsertionException.cs`, and `ProcessNameException.cs`:
Provide custom exception handling for database interactions.

#### `FailedScanService.cs`:
Provides a controlled logging system for faulting Scan output parses.
- `OutputFile` property routes to the database's failed scan log file.
- `LogFailedScanEvent()` method writes a Log message, with exception info, to the failed scans log.

#### `ScanEventInsertionService.cs`:
Provides validation measures to test the insertion of a `ScanEvent` object into the Database.
- `ScanFolder` property routes to the database's scan tables directory.
- `CompareDatesAsRange()` method checks that two dates are within a set range of each other.
- `Compare()` method checks if a `ScanEvent` and database entry are Scans of the same Label.
- `ComparePreviousEvent()` method checks if a `ScanEvent` matches the Label of an entry in the Previous Process' table.
- `ValidatePreviousProcess()` method checks if a `ScanEvent` has a matching scan in its previous process.
- `ValidateDuplicateScan()` method confirms that a `ScanEvent`'s Label has not already been scanned.

#### `EventRouter.cs`
Powers the actual routing and insertion of scan output into the proper Process data tables.
- `ScanFolder` property routes to the database's scan tables directory.
- `GetSerialNumber()` method configures a `SerialNumber` object from a `ScanEvent` object's data.
- `Route()` method analyses a `ScanEvent` object and attempts to insert it to the proper Process data table.

## Removed classes

**List any classes or members that have been removed or deprecated by this pull request.**

#### All `LotCom` Model classes.

## Impact

**Discuss any potential impacts this feature may have on existing functionalities.**

Because this PR solely implements new classes and members, there should be no impact to existing functionality.

## Checklist

- [X] Code follows the project's coding standards

- [X] The documentation has been updated to reflect the new feature

## Additional Notes

**Any additional information or context relevant to this PR.**

Signed-off-by: Mason Ritchason <masonritchason@gmail.com>