### PR TITLE
bug/21

### DIFF
--- a/LotComWatcher/Models/Services/NetworkService.cs
+++ b/LotComWatcher/Models/Services/NetworkService.cs
@@ -125,7 +125,7 @@ public sealed class NetworkService
     /// <returns>'true' if Message was successfully sent to ScannerAddress.</returns>
     /// <exception cref="SystemException"></exception>
     /// <exception cref="ArgumentException"></exception>
-    public static async Task<bool> SendDataValidationError(IPAddress ScannerAddress, string LCDText, int Duration)
+    public async Task<bool> SendDataValidationError(IPAddress ScannerAddress, string LCDText, int Duration)
     {
         // send Data Validation Failure and Send Alert DMCCs to the Scanner
         try
@@ -157,7 +157,7 @@ public sealed class NetworkService
     /// <returns>'true' if Message was successfully sent to ScannerAddress.</returns>
     /// <exception cref="SystemException"></exception>
     /// <exception cref="ArgumentException"></exception>
-    public static async Task<bool> SendMissingPreviousScanError(IPAddress ScannerAddress, int Duration, List<string> PreviousProcess)
+    public async Task<bool> SendMissingPreviousScanError(IPAddress ScannerAddress, int Duration, List<string> PreviousProcess)
     {
         // send Data Validation Failure and Send Alert DMCCs to the Scanner
         try
@@ -188,7 +188,7 @@ public sealed class NetworkService
     /// <returns>'true' if Message was successfully sent to ScannerAddress.</returns>
     /// <exception cref="SystemException"></exception>
     /// <exception cref="ArgumentException"></exception>
-    public static async Task<bool> SendDuplicateScanError(IPAddress ScannerAddress, int Duration)
+    public async Task<bool> SendDuplicateScanError(IPAddress ScannerAddress, int Duration)
     {
         // send Data Validation Failure and Send Alert DMCCs to the Scanner
         try

--- a/LotComWatcher/Models/Services/NetworkService.cs
+++ b/LotComWatcher/Models/Services/NetworkService.cs
@@ -16,11 +16,9 @@ public sealed class NetworkService
     /// </summary>
     /// <param name="EndPoint"></param>
     /// <returns>'true' if the Ping was able to connect successfully.</returns>
-    /// <exception cref="ArgumentException"></exception>
-    /// <exception cref="OperationCanceledException"></exception>
     /// <exception cref="SocketException"></exception>
     /// <exception cref="SystemException"></exception>
-    private async Task<bool> Ping(TcpClient Client, IPEndPoint EndPoint)
+    private static async Task<bool> Ping(TcpClient Client, IPEndPoint EndPoint)
     {
         // attempt to connect to the EndPoint
         try
@@ -30,12 +28,12 @@ public sealed class NetworkService
         // there was an error while accessing the Socket on the endpoint
         catch (SocketException)
         {
-            throw;
+            throw new SocketException((int)SocketError.HostUnreachable);
         }
         // either the Host on the endpoint of the DefaultPort was invalid (null, out of range, etc.)
         catch (ArgumentException)
         {
-            throw new ArgumentException("The Host is null or the Port Number is invalid. Cannot establish connection.");
+            throw new SocketException((int)SocketError.HostNotFound);
         }
         // the TCP client was closed before or while the connection was established
         catch (ObjectDisposedException)
@@ -45,7 +43,7 @@ public sealed class NetworkService
         // the operation's cancellation token was thrown internally
         catch (OperationCanceledException)
         {
-            throw;
+            throw new SystemException("The operation terminated unexpectedly. Cannot establish connection.");
         }
         // connection was established without exceptions
         return true;
@@ -65,17 +63,40 @@ public sealed class NetworkService
     /// <param name="ScannerAddress"></param>
     /// <param name="Message"></param>
     /// <returns>'true' if Message was successfully sent to ScannerAddress.</returns>
-    /// <exception cref="HttpRequestException"></exception>
+    /// <exception cref="SystemException"></exception>
     /// <exception cref="ArgumentException"></exception>
-    public async Task<bool> SendMessage(IPAddress ScannerAddress, string Message)
+    public static async Task<bool> SendMessage(IPAddress ScannerAddress, string Message)
     {
         TcpClient MessageClient = new TcpClient();
         // initialize a TCP endoint that connects to the targeted scanner
         IPEndPoint EndPoint = new IPEndPoint(ScannerAddress, DefaultPort);
         // ping the connection to the scanner to ensure messaging will occur
-        if (!await Ping(MessageClient, EndPoint))
+        bool Connected = false;
+        try
         {
-            throw new HttpRequestException(HttpRequestError.ConnectionError);
+            Connected = await Ping(MessageClient, EndPoint);
+        }
+        // there was a connection error
+        catch (SocketException _ex)
+        {
+            if (_ex.SocketErrorCode == SocketError.HostNotFound)
+            {
+                throw new ArgumentException("The requested Scanner address is unavailable.");
+            }
+            else if (_ex.SocketErrorCode == SocketError.HostUnreachable)
+            {
+                throw new ArgumentException("There is no Scanner at the requested address.");
+            }
+        }
+        // there was an internal system error
+        catch (SystemException)
+        {
+            throw;
+        }
+        // confirm connection
+        if (!Connected)
+        {
+            throw new SystemException("The connection could not be established.");
         }
         // create the message stream and encode the string Message onto the stream
         NetworkStream MessageStream = MessageClient.GetStream();
@@ -102,9 +123,9 @@ public sealed class NetworkService
     /// <param name="LCDText"></param>
     /// <param name="Duration"></param>
     /// <returns>'true' if Message was successfully sent to ScannerAddress.</returns>
-    /// <exception cref="HttpRequestException"></exception>
+    /// <exception cref="SystemException"></exception>
     /// <exception cref="ArgumentException"></exception>
-    public async Task<bool> SendDataValidationError(IPAddress ScannerAddress, string LCDText, int Duration)
+    public static async Task<bool> SendDataValidationError(IPAddress ScannerAddress, string LCDText, int Duration)
     {
         // send Data Validation Failure and Send Alert DMCCs to the Scanner
         try
@@ -115,13 +136,13 @@ public sealed class NetworkService
                 await SendMessage(ScannerAddress, $"||>UI.SEND-ALERT {Duration} 2 \"{LCDText}\"\r\n");
             }
         }
-        catch (HttpRequestException)
-        {
-            throw;
-        }
         catch (ArgumentException)
         {
-            throw;
+            throw new SystemException("Could not establish a connection to the Scanner.");
+        }
+        catch (SystemException)
+        {
+            throw new SystemException("Failed to request a connection.");
         }
         return true;
     }
@@ -134,9 +155,9 @@ public sealed class NetworkService
     /// <param name="Duration"></param>
     /// <param name="PreviousProcess"></param>
     /// <returns>'true' if Message was successfully sent to ScannerAddress.</returns>
-    /// <exception cref="HttpRequestException"></exception>
+    /// <exception cref="SystemException"></exception>
     /// <exception cref="ArgumentException"></exception>
-    public async Task<bool> SendMissingPreviousScanError(IPAddress ScannerAddress, int Duration, List<string> PreviousProcess)
+    public static async Task<bool> SendMissingPreviousScanError(IPAddress ScannerAddress, int Duration, List<string> PreviousProcess)
     {
         // send Data Validation Failure and Send Alert DMCCs to the Scanner
         try
@@ -147,13 +168,13 @@ public sealed class NetworkService
                 await SendMessage(ScannerAddress, $"||>UI.SEND-ALERT {Duration} 2 \"This Label was not scanned by {PreviousProcess[0]}. Basket is not valid for use.\"\r\n");
             }
         }
-        catch (HttpRequestException)
-        {
-            throw;
-        }
         catch (ArgumentException)
         {
-            throw;
+            throw new SystemException("Could not establish a connection to the Scanner.");
+        }
+        catch (SystemException)
+        {
+            throw new SystemException("Failed to request a connection.");
         }
         return true;
     }
@@ -165,9 +186,9 @@ public sealed class NetworkService
     /// <param name="ScannerAddress"></param>
     /// <param name="Duration"></param>
     /// <returns>'true' if Message was successfully sent to ScannerAddress.</returns>
-    /// <exception cref="HttpRequestException"></exception>
+    /// <exception cref="SystemException"></exception>
     /// <exception cref="ArgumentException"></exception>
-    public async Task<bool> SendDuplicateScanError(IPAddress ScannerAddress, int Duration)
+    public static async Task<bool> SendDuplicateScanError(IPAddress ScannerAddress, int Duration)
     {
         // send Data Validation Failure and Send Alert DMCCs to the Scanner
         try
@@ -178,13 +199,13 @@ public sealed class NetworkService
                 await SendMessage(ScannerAddress, $"||>UI.SEND-ALERT {Duration} 2 \"Duplicate Label scanned.\"\r\n");
             }
         }
-        catch (HttpRequestException)
-        {
-            throw;
-        }
         catch (ArgumentException)
         {
-            throw;
+            throw new SystemException("Could not establish a connection to the Scanner.");
+        }
+        catch (SystemException)
+        {
+            throw new SystemException("Failed to request a connection.");
         }
         return true;
     }

--- a/LotComWatcher/Worker.cs
+++ b/LotComWatcher/Worker.cs
@@ -134,14 +134,15 @@ public class Worker : BackgroundService
                                     PreviousProcess: _output.Process.PreviousProcesses!
                                 );
                             }
-                            // the message failed to send
-                            catch (HttpRequestException)
-                            {
-                                Logger.LogError("\tFailed to connect to the Scanner to send Message.");
-                            }
+                            // the connection was refused (not found or unavailable)
                             catch (ArgumentException)
                             {
-                                Logger.LogError("\tThe IP Address and/or endpoint refused to produce a connection.");
+                                Logger.LogError($"\tThe Scanner at {_output.Address} refused to produce a connection.");
+                            }
+                            // the message failed to send due to a system issue
+                            catch (SystemException)
+                            {
+                                Logger.LogError($"\tFailed to connect to the Scanner at {_output.Address}.");
                             }
                         }
                         // the Label was already scanned at this Process
@@ -157,14 +158,15 @@ public class Worker : BackgroundService
                                     Duration: 15
                                 );
                             }
-                            // the message failed to send
-                            catch (HttpRequestException)
-                            {
-                                Logger.LogError("\tFailed to connect to the Scanner to send Message.");
-                            }
+                            // the connection was refused (not found or unavailable)
                             catch (ArgumentException)
                             {
-                                Logger.LogError("\tThe IP Address and/or endpoint refused to produce a connection.");
+                                Logger.LogError($"\tThe Scanner at {_output.Address} refused to produce a connection.");
+                            }
+                            // the message failed to send due to a system issue
+                            catch (SystemException)
+                            {
+                                Logger.LogError($"\tFailed to connect to the Scanner at {_output.Address}.");
                             }
                         }
                         // the Scan was valid

--- a/LotComWatcher/Worker.cs
+++ b/LotComWatcher/Worker.cs
@@ -1,4 +1,3 @@
-using LotCom.Types;
 using LotComWatcher.Models.Datasources;
 using LotComWatcher.Models.Datatypes;
 using LotComWatcher.Models.Enums;
@@ -67,6 +66,89 @@ public class Worker : BackgroundService
     }
 
     /// <summary>
+    /// Reads the scan output file and parses a List of ScanOutput objects.
+    /// </summary>
+    /// <returns></returns>
+    /// <exception cref="FileLoadException"></exception>
+    private async Task<ScanOutput[]> GetScans()
+    {
+        // read the scan output file
+        List<string> ScanOutputs;
+        try
+        {
+            ScanOutputs = await Reader.Read();
+        }
+        catch (OperationCanceledException _ex)
+        {
+            // log the exception and exit the Service
+            Logger.LogError(_ex, "{Message}", _ex.Message);
+            return [];
+        }
+        // asynchronously parse each Raw Scan into a ScanOutput object
+        List<Task<ScanOutput>> ParseTasks = await ClearFaultingParses(ScanOutputs);
+        return await Task.WhenAll(ParseTasks);
+    }
+
+    /// <summary>
+    /// Logs a console message stating that Output was missing a Scan at the previous Process.
+    /// </summary>
+    /// <param name="Output"></param>
+    /// <returns></returns>
+    private async Task LogMissingPreviousScan(ScanOutput Output)
+    {
+        // log to the console and send a message to the Scanner
+        Logger.LogWarning("Missing Scan in previous Process.");
+        try
+        {
+            await Network.SendMissingPreviousScanError
+            (
+                ScannerAddress: Output.Address,
+                Duration: 15,
+                PreviousProcess: Output.Process.PreviousProcesses!
+            );
+        }
+        // the connection was refused (not found or unavailable)
+        catch (ArgumentException)
+        {
+            Logger.LogError($"\tThe Scanner at {Output.Address} refused to produce a connection.");
+        }
+        // the message failed to send due to a system issue
+        catch (SystemException)
+        {
+            Logger.LogError($"\tFailed to connect to the Scanner at {Output.Address}.");
+        }
+    }
+
+    /// <summary>
+    /// Logs a console message stating that Output was a duplicate Scan.
+    /// </summary>
+    /// <param name="Output"></param>
+    /// <returns></returns>
+    private async Task LogDuplicateScan(ScanOutput Output)
+    {
+        // log to the console and send a message to the Scanner
+        Logger.LogWarning("Duplicate Scan.");
+        try
+        {
+            await Network.SendDuplicateScanError
+            (
+                ScannerAddress: Output.Address,
+                Duration: 15
+            );
+        }
+        // the connection was refused (not found or unavailable)
+        catch (ArgumentException)
+        {
+            Logger.LogError($"\tThe Scanner at {Output.Address} refused to produce a connection.");
+        }
+        // the message failed to send due to a system issue
+        catch (SystemException)
+        {
+            Logger.LogError($"\tFailed to connect to the Scanner at {Output.Address}.");
+        }
+    }
+
+    /// <summary>
     /// Defines the service's event loop while running.
     /// </summary>
     /// <param name="stoppingToken"></param>
@@ -78,106 +160,40 @@ public class Worker : BackgroundService
         {
             while (!stoppingToken.IsCancellationRequested)
             {
-                // read the Scan Output file
-                List<string> ScanOutputs = [];
-                try
-                {
-                    ScanOutputs = await Reader.Read();
-                }
-                catch (OperationCanceledException _ex)
-                {
-                    // log the exception and exit the Service
-                    Logger.LogError(_ex, "{Message}", _ex.Message);
-                    Environment.Exit(1);
-                }
-                // asynchronously parse each Raw Scan into a ScanOutput object
-                List<Task<ScanOutput>> ParseTasks = await ClearFaultingParses(ScanOutputs);
-                ScanOutput[] ParseResults = await Task.WhenAll(ParseTasks);
-                // confirm that the parsing did not fail and/or return null
-                if (ParseResults is null)
+                // read the Scan Output file; confirm parsing did not fail/return null
+                ScanOutput[] Outputs = await GetScans();
+                if (Outputs is null || Outputs.Length < 1)
                 {
                     Logger.LogInformation("No new Scans.");
+                    continue;
                 }
-                else
+                // create scans in Database
+                DatabaseContext? DbContext = null;
+                foreach (ScanOutput _output in Outputs)
                 {
-                    // create scans in Database
-                    Process? PriorIterationProcess = null;
-                    DatabaseContext? DbContext = null;
-                    foreach (ScanOutput _output in ParseResults)
+                    // attempt to use the same DatabaseContext as the previous iteration
+                    if (DbContext is null || !DbContext.Process.FullName.Equals(_output.Process.FullName))
                     {
-                        // attempt to use the same DatabaseContext as the previous iteration
-                        if
-                        (
-                            PriorIterationProcess is null
-                            || DbContext is null
-                            || !PriorIterationProcess.FullName.Equals(_output.Process.FullName)
-                        )
-                        {
-                            // db context is not for the needed Process; make a new one
-                            DbContext = new DatabaseContext(_output.Process);
-                        }
-                        // update iteration process
-                        PriorIterationProcess = _output.Process;
-                        // capture the message from the Manager on each ScanOutput and Log a respective string
-                        InsertionMessage Message = await DbContext.CreateScan(_output);
-                        // no scan occurred at the previous process
-                        if (Message == InsertionMessage.MissingPrevious)
-                        {
-                            // log to the console and send a message to the Scanner
-                            Logger.LogWarning("Missing Scan in previous Process.");
-                            try
-                            {
-                                await Network.SendMissingPreviousScanError
-                                (
-                                    ScannerAddress: _output.Address,
-                                    Duration: 15,
-                                    PreviousProcess: _output.Process.PreviousProcesses!
-                                );
-                            }
-                            // the connection was refused (not found or unavailable)
-                            catch (ArgumentException)
-                            {
-                                Logger.LogError($"\tThe Scanner at {_output.Address} refused to produce a connection.");
-                            }
-                            // the message failed to send due to a system issue
-                            catch (SystemException)
-                            {
-                                Logger.LogError($"\tFailed to connect to the Scanner at {_output.Address}.");
-                            }
-                        }
-                        // the Label was already scanned at this Process
-                        else if (Message == InsertionMessage.DuplicateScan)
-                        {
-                            // log to the console and send a message to the Scanner
-                            Logger.LogWarning("Duplicate Scan.");
-                            try
-                            {
-                                await Network.SendDuplicateScanError
-                                (
-                                    ScannerAddress: _output.Address,
-                                    Duration: 15
-                                );
-                            }
-                            // the connection was refused (not found or unavailable)
-                            catch (ArgumentException)
-                            {
-                                Logger.LogError($"\tThe Scanner at {_output.Address} refused to produce a connection.");
-                            }
-                            // the message failed to send due to a system issue
-                            catch (SystemException)
-                            {
-                                Logger.LogError($"\tFailed to connect to the Scanner at {_output.Address}.");
-                            }
-                        }
-                        // the Scan was valid
-                        else
-                        {
-                            Logger.LogInformation("Created new Scan entry.");
-                        }
+                        // db context is not for the needed Process; make a new one
+                        DbContext = new DatabaseContext(_output.Process);
                     }
+                    // perform CRUD create operation and record the message from the DbContext
+                    InsertionMessage Message = await DbContext.CreateScan(_output);
+                    // no scan occurred at the previous process
+                    if (Message == InsertionMessage.MissingPrevious)
+                    {
+                        await LogMissingPreviousScan(_output);
+                        continue;
+                    }
+                    // the Label was already scanned at this Process
+                    else if (Message == InsertionMessage.DuplicateScan)
+                    {
+                        await LogDuplicateScan(_output);
+                        continue;
+                    }
+                    // the Scan was valid
+                    Logger.LogInformation("Created new Scan entry.");
                 }
-                // loop every 500 milliseconds (1/2 second)
-                await Task.Delay(TimeSpan.FromMilliseconds(500), stoppingToken);
             }
         }
         catch (OperationCanceledException)


### PR DESCRIPTION
# bug/21

## Addressed Bug Report
Resolves #21 

## Summary

**Briefly describe the bug being resolved.**

Network failures cause unhandled `SocketException` throws.

## Root Cause(s)/Faults

**Give a detailed explanation of the root causes addressed by this pull request.**

No exception handling structures were put in place in the original implementation.

## Rationale

**Explain the reasoning behind the solution introduced by this pull request and any additional benefits to the project.**

Network issues are inevitable, especially due to the Scanners' tendency to go into "sleep" mode when not used for a while. These exceptions would constantly kill the service and most importantly, the logging would not be successful.

## Changes

**List the major changes made in this pull request.**

#### `NetworkService.cs`:
- Refactor `Ping()`, `SendMessage()`, `SendDataValidationError()`, `SendMissingPreviousScanError()`, `SendDuplicateScanError()`
  - Improve exception handling structures and thrown exceptions.

#### `Worker.cs`:
- Add `GetScans()` method:
  - Retrieves all of the new `ScanOutput` objects from the LotCom database.
- Add `LogMissingPreviousScan()` and `LogDuplicateScan()` methods:
  - Perform logging and messaging operations for the corresponding invalidity case.
- Refactor `ExecuteAsync()` method:
  - Improve processing speed using `continue` keyword in iteration completion cases.

## New classes

**List any new classes or members implemented in this pull request.**

## Removed classes

**List any classes or members that have been removed or deprecated by this pull request.**

## Impact

**Discuss any potential impacts this feature may have on existing functionalities.**

The changes to `Worker` should be monitored to ensure that the processing changes don't negatively impact functionality.

## Checklist

- [X] Code follows the project's coding standards

- [X] The solution thoroughly and effectively addresses the root cause mentioned above

- [X] The documentation has been updated to reflect the new feature

## Additional Notes

**Any additional information or context relevant to this PR.**