### PR TITLE
feat/1.0.21

### DIFF
--- a/LotComWatcher/Models/Datatypes/ScanOutput.cs
+++ b/LotComWatcher/Models/Datatypes/ScanOutput.cs
@@ -27,11 +27,6 @@ namespace LotComWatcher.Models.Datatypes;
 public class ScanOutput(Process ScanProcess, DateTime ScanDate, IPAddress ScanAddress, Process LabelProcess, Part LabelPart, VariableFieldSet LabelVariableFields, DateTime LabelProductionDate, PartialDataSet LabelPrimaryData, PartialDataSet? LabelSecondaryData = null, PartialDataSet? LabelTertiaryData = null)
 {
     /// <summary>
-    /// A UserAgent object that can be used to authorize API calls from this object.
-    /// </summary>
-    private static UserAgent Agent = UserAgentFactory.CreateWatcherAgent(System.Reflection.Assembly.GetEntryAssembly()!.GetName().Version!.ToString());
-
-    /// <summary>
     /// The Process that produced the ScanOutput.
     /// </summary>
     public Process ScanProcess = ScanProcess;
@@ -87,13 +82,13 @@ public class ScanOutput(Process ScanProcess, DateTime ScanDate, IPAddress ScanAd
     /// <param name="ProcessFullName"></param>
     /// <returns></returns>
     /// <exception cref="DatabaseException"></exception>
-    private static async Task<Process?> RetrieveProcess(string ProcessFullName)
+    private static async Task<Process?> RetrieveProcess(string ProcessFullName, HttpClient Client, UserAgent Agent)
     {
         // retrieve all Processes from the Database
         IEnumerable<Process>? ProcessesFromDatabase;
         try
         {
-            ProcessesFromDatabase = await ProcessService.GetAll(Agent);
+            ProcessesFromDatabase = await ProcessService.GetAll(Client, Agent);
         }
         // some database-generated issue
         catch (HttpRequestException _ex)
@@ -124,13 +119,13 @@ public class ScanOutput(Process ScanProcess, DateTime ScanDate, IPAddress ScanAd
     /// <param name="ScannedBy"></param>
     /// <returns></returns>
     /// <exception cref="DatabaseException"></exception>
-    private static async Task<Part?> RetrievePart(string PartNumber, int ScannedBy)
+    private static async Task<Part?> RetrievePart(string PartNumber, int ScannedBy, HttpClient Client, UserAgent Agent)
     {
         // retrieve all Parts from the Database
         IEnumerable<Part>? PartsFromDatabase;
         try
         {
-            PartsFromDatabase = await PartService.GetPrintedByProcess(ScannedBy, Agent);
+            PartsFromDatabase = await PartService.GetPrintedByProcess(ScannedBy, Client, Agent);
         }
         // some database-generated issue
         catch (HttpRequestException _ex)
@@ -163,24 +158,24 @@ public class ScanOutput(Process ScanProcess, DateTime ScanDate, IPAddress ScanAd
     /// <exception cref="FormatException"></exception>
     /// <exception cref="DatabaseException"></exception>
     /// <exception cref="OverflowException"></exception>
-    public static async Task<ScanOutput> ParseCSV(string CSVLine)
+    public static async Task<ScanOutput> ParseCSV(string CSVLine, HttpClient Client, UserAgent Agent)
     {
         // split the line by the comma character
         string[] SplitLine = CSVLine.Split(',');
         // attempt to retrieve the ScanOutput's ScanProcess
-        Process? ScanProcess = await RetrieveProcess(SplitLine[0]);
+        Process? ScanProcess = await RetrieveProcess(SplitLine[0], Client, Agent);
         if (ScanProcess is null)
         {
             throw new ArgumentException($"Could not retrieve a Process like '{SplitLine[0]}'.");
         }
         // attempt to retrieve the ScanOutput's LabelProcess
-        Process? LabelProcess = await RetrieveProcess(SplitLine[3]);
+        Process? LabelProcess = await RetrieveProcess(SplitLine[3], Client, Agent);
         if (LabelProcess is null)
         {
             throw new ArgumentException($"Could not retrieve a Process like '{SplitLine[3]}'.");
         }
         // attempt to retrieve the ScanOutput's LabelPart
-        Part? LabelPart = await RetrievePart(SplitLine[4], LabelProcess.Id);
+        Part? LabelPart = await RetrievePart(SplitLine[4], LabelProcess.Id, Client, Agent);
         if (LabelPart is null)
         {
             throw new ArgumentException($"Could not retrieve a Part like '{SplitLine[4]}'.");

--- a/LotComWatcher/Models/Services/ReaderService.cs
+++ b/LotComWatcher/Models/Services/ReaderService.cs
@@ -1,3 +1,4 @@
+using LotCom.Database.Auth;
 using LotComWatcher.Models.Datatypes;
 using LotComWatcher.Models.Exceptions;
 
@@ -17,7 +18,7 @@ public static class ReaderService
     /// Parses string-based Scan outputs to an IEnumerable of ScanOutput objects.
     /// </summary>
     /// <returns></returns>
-    private static async Task<IEnumerable<ScanOutput>> ParseScans(IEnumerable<string> RawScans)
+    private static async Task<IEnumerable<ScanOutput>> ParseScans(IEnumerable<string> RawScans, HttpClient Client, UserAgent Agent)
     {
         // check for faulting parses and remove them from the enumerable
         IEnumerable<Task<ScanOutput>> ParseTasks = [];
@@ -26,7 +27,7 @@ public static class ReaderService
             Task<ScanOutput>? Parse;
             try
             {
-                Parse = ScanOutput.ParseCSV(_raw);
+                Parse = ScanOutput.ParseCSV(_raw, Client, Agent);
             }
             catch
             {
@@ -51,7 +52,7 @@ public static class ReaderService
     /// </summary>
     /// <returns>An IEnumerable of Scan results as ScanOutput objects.</returns>
     /// <exception cref="OutputFileAccessException"></exception>
-    public static async Task<IEnumerable<ScanOutput>> ReadNewScans()
+    public static async Task<IEnumerable<ScanOutput>> ReadNewScans(HttpClient Client, UserAgent Agent)
     {
         // attempt to read the Scan Output file and throw an access exception if the read fails
         IEnumerable<string> RawScans;
@@ -70,7 +71,7 @@ public static class ReaderService
             );
         }
         // parse ScanOutput objects from the Raw Scans
-        IEnumerable<ScanOutput> ParsedScans = await ParseScans(RawScans);
+        IEnumerable<ScanOutput> ParsedScans = await ParseScans(RawScans, Client, Agent);
         // clear the file contents and return new Scan outputs
         await File.WriteAllTextAsync(OutputFile, "");
         return ParsedScans;

--- a/LotComWatcher/Program.cs
+++ b/LotComWatcher/Program.cs
@@ -1,3 +1,5 @@
+using LotCom.Database.Auth;
+using LotCom.Database.Http;
 using LotComWatcher;
 
 var builder = Host.CreateApplicationBuilder(args);
@@ -6,6 +8,14 @@ builder.Services.AddWindowsService(options =>
 {
     options.ServiceName = "LotCom Watcher microservice";
 });
+
+// inject an HttpClient for the app
+UserAgent Agent = UserAgentFactory.CreateWatcherAgent(System.Reflection.Assembly.GetEntryAssembly()!.GetName().Version!.ToString());
+builder.Services.AddSingleton(Agent);
+HttpClient Http = HttpClientFactory.Create(Agent);
+builder.Services.AddSingleton(Http);
+
+// inject the Worker service
 builder.Services.AddHostedService<Worker>();
 
 var host = builder.Build();

--- a/LotComWatcher/Worker.cs
+++ b/LotComWatcher/Worker.cs
@@ -18,17 +18,24 @@ public class Worker : BackgroundService
     private readonly ILogger<Worker> Logger;
 
     /// <summary>
-    /// A UserAgent object that can be used to authorize API calls from this object.
+    /// UserAgent used to authenticate API calls in the LotCom system.
     /// </summary>
-    private readonly UserAgent Agent = UserAgentFactory.CreateWatcherAgent(System.Reflection.Assembly.GetEntryAssembly()!.GetName().Version!.ToString());
+    private readonly UserAgent Agent;
+
+    /// <summary>
+    /// HttpClient configured to communicate with the LotCom system.
+    /// </summary>
+    private readonly HttpClient Http;
 
     /// <summary>
     /// Creates a Service Worker that performs the Service's main event/work loop.
     /// </summary>
     /// <param name="Logger"></param>
-    public Worker(ILogger<Worker> Logger)
+    public Worker(ILogger<Worker> Logger, HttpClient Http, UserAgent Agent)
     {
         this.Logger = Logger;
+        this.Http = Http;
+        this.Agent = Agent;
     }
 
     /// <summary>
@@ -77,7 +84,7 @@ public class Worker : BackgroundService
             IEnumerable<Scan>? ScansFromDatabase;
             try
             {
-                ScansFromDatabase = await ScanService.GetAllWithinRange(60, Agent);
+                ScansFromDatabase = await ScanService.GetAllWithinRange(60, Http, Agent);
             }
             // some database-generated issue
             catch (HttpRequestException _ex)
@@ -100,7 +107,7 @@ public class Worker : BackgroundService
                 ScansFromDatabase = ScansFromDatabase
                     .Where(x => x.CompareDateWithinRange(60, DateTime.Now));
                 // read the Scan Output file; confirm parsing did not fail/return null
-                IEnumerable<ScanOutput> Outputs = await ReaderService.ReadNewScans();
+                IEnumerable<ScanOutput> Outputs = await ReaderService.ReadNewScans(Http, Agent);
                 if (!Outputs.Any())
                 {
                     continue;
@@ -126,7 +133,7 @@ public class Worker : BackgroundService
                     bool Created;
                     try
                     {
-                        Created = await ScanService.Create(ScanToCreate, Agent);
+                        Created = await ScanService.Create(ScanToCreate, Http, Agent);
                     }
                     // some database-generated issue
                     catch (HttpRequestException _ex)


### PR DESCRIPTION
# feat/1.0.21

## Addressed Feature Request
No tracked issue resolutions.

## Summary

**Briefly describe the feature being introduced.**

This PR implements `HttpClient` and `UserAgent` dependency injection to resolve an issue where **LotCom Watcher** is overloading the DNS and SSL of its backend server.

## Rationale

**Explain the reasoning behind this feature and its benefits to the project.**

In **LotCom Libraries**, `DAL` `Service` classes formerly created a new `HttpClient` each time one of their methods were called. This meant that, for apps such as **LotCom Watcher** that create thousands of API calls, services were susceptible to overloading and crashing their own communications on networks with thousands of `HttpClient` instances. 

Now, the methods require an externally created `HttpClient`, which means that DI can be used to create a single instance for each LotCom app.

## Changes

**List the major changes made in this pull request.**

#### `ScanOutput.cs` and `ReaderService.cs`:
- Refactor methods that interact with API:
  - Require the app's `HttpClient` and `UserAgent` to be passed.

#### `Worker.cs`:
- Refactor to require DI of `HttpClient` and `UserAgent` services.

#### `Program.cs`:
- Add dependency injection of `HttpClient` and `UserAgent` classes.

## New classes

**List any new classes or members implemented in this pull request.**

## Removed classes

**List any classes or members that have been removed or deprecated by this pull request.**

## Impact

**Discuss any potential impacts this feature may have on existing functionalities.**

This is a hotfix aiming to restore intended functionality, so it will not impact in any negative way.

## Checklist

- [X] Code follows the project's coding standards

- [X] The documentation has been updated to reflect the new feature

## Additional Notes

**Any additional information or context relevant to this PR.**