### PR TITLE
1.0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,9 @@
 - `ReaderService` outputs process-ready `ScanOutput` objects and reads from a new location.
 - `ScanValidationService` performs unique scan, valid process, valid part, existing previous process scan, and required field validations.
 - `Worker.cs` now operates on the last 60 days of Scans instead of the entire database (much faster).
+
+## `1.0.21`
+#### Hotfix
+- [`feat/1.0.21`](https://github.com/LotCom/LotCom-watcher/pull/36):
+  - Integrate with change to `DAL` in **LotCom Libraries** that requires the LotCom apps to provide their own `HttpClient`.
+  - Add dependency injection of `HttpClient` and `UserAgent` services.

--- a/LICENSE
+++ b/LICENSE
@@ -629,7 +629,7 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    LotCoM Watcher, a component of the LotCoM ERP system.
+    LotCom Watcher, a component of the LotCom ERP system.
     Copyright (C) 2025 Mason Ritchason
 
     This program is free software: you can redistribute it and/or modify

--- a/LotComWatcher/LotComWatcher.csproj
+++ b/LotComWatcher/LotComWatcher.csproj
@@ -10,7 +10,7 @@
 		<!-- Restore NuGet packages with packages.lock.json file -->
 		<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <!-- Versions -->
-		<ApplicationDisplayVersion>1.0.2</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>1.0.21</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
   </PropertyGroup>
 

--- a/LotComWatcher/Models/Datatypes/ScanOutput.cs
+++ b/LotComWatcher/Models/Datatypes/ScanOutput.cs
@@ -27,11 +27,6 @@ namespace LotComWatcher.Models.Datatypes;
 public class ScanOutput(Process ScanProcess, DateTime ScanDate, IPAddress ScanAddress, Process LabelProcess, Part LabelPart, VariableFieldSet LabelVariableFields, DateTime LabelProductionDate, PartialDataSet LabelPrimaryData, PartialDataSet? LabelSecondaryData = null, PartialDataSet? LabelTertiaryData = null)
 {
     /// <summary>
-    /// A UserAgent object that can be used to authorize API calls from this object.
-    /// </summary>
-    private static UserAgent Agent = UserAgentFactory.CreateWatcherAgent(System.Reflection.Assembly.GetEntryAssembly()!.GetName().Version!.ToString());
-
-    /// <summary>
     /// The Process that produced the ScanOutput.
     /// </summary>
     public Process ScanProcess = ScanProcess;
@@ -87,13 +82,13 @@ public class ScanOutput(Process ScanProcess, DateTime ScanDate, IPAddress ScanAd
     /// <param name="ProcessFullName"></param>
     /// <returns></returns>
     /// <exception cref="DatabaseException"></exception>
-    private static async Task<Process?> RetrieveProcess(string ProcessFullName)
+    private static async Task<Process?> RetrieveProcess(string ProcessFullName, HttpClient Client, UserAgent Agent)
     {
         // retrieve all Processes from the Database
         IEnumerable<Process>? ProcessesFromDatabase;
         try
         {
-            ProcessesFromDatabase = await ProcessService.GetAll(Agent);
+            ProcessesFromDatabase = await ProcessService.GetAll(Client, Agent);
         }
         // some database-generated issue
         catch (HttpRequestException _ex)
@@ -124,13 +119,13 @@ public class ScanOutput(Process ScanProcess, DateTime ScanDate, IPAddress ScanAd
     /// <param name="ScannedBy"></param>
     /// <returns></returns>
     /// <exception cref="DatabaseException"></exception>
-    private static async Task<Part?> RetrievePart(string PartNumber, int ScannedBy)
+    private static async Task<Part?> RetrievePart(string PartNumber, int ScannedBy, HttpClient Client, UserAgent Agent)
     {
         // retrieve all Parts from the Database
         IEnumerable<Part>? PartsFromDatabase;
         try
         {
-            PartsFromDatabase = await PartService.GetPrintedByProcess(ScannedBy, Agent);
+            PartsFromDatabase = await PartService.GetPrintedByProcess(ScannedBy, Client, Agent);
         }
         // some database-generated issue
         catch (HttpRequestException _ex)
@@ -163,24 +158,24 @@ public class ScanOutput(Process ScanProcess, DateTime ScanDate, IPAddress ScanAd
     /// <exception cref="FormatException"></exception>
     /// <exception cref="DatabaseException"></exception>
     /// <exception cref="OverflowException"></exception>
-    public static async Task<ScanOutput> ParseCSV(string CSVLine)
+    public static async Task<ScanOutput> ParseCSV(string CSVLine, HttpClient Client, UserAgent Agent)
     {
         // split the line by the comma character
         string[] SplitLine = CSVLine.Split(',');
         // attempt to retrieve the ScanOutput's ScanProcess
-        Process? ScanProcess = await RetrieveProcess(SplitLine[0]);
+        Process? ScanProcess = await RetrieveProcess(SplitLine[0], Client, Agent);
         if (ScanProcess is null)
         {
             throw new ArgumentException($"Could not retrieve a Process like '{SplitLine[0]}'.");
         }
         // attempt to retrieve the ScanOutput's LabelProcess
-        Process? LabelProcess = await RetrieveProcess(SplitLine[3]);
+        Process? LabelProcess = await RetrieveProcess(SplitLine[3], Client, Agent);
         if (LabelProcess is null)
         {
             throw new ArgumentException($"Could not retrieve a Process like '{SplitLine[3]}'.");
         }
         // attempt to retrieve the ScanOutput's LabelPart
-        Part? LabelPart = await RetrievePart(SplitLine[4], LabelProcess.Id);
+        Part? LabelPart = await RetrievePart(SplitLine[4], LabelProcess.Id, Client, Agent);
         if (LabelPart is null)
         {
             throw new ArgumentException($"Could not retrieve a Part like '{SplitLine[4]}'.");

--- a/LotComWatcher/Models/Services/ReaderService.cs
+++ b/LotComWatcher/Models/Services/ReaderService.cs
@@ -1,3 +1,4 @@
+using LotCom.Database.Auth;
 using LotComWatcher.Models.Datatypes;
 using LotComWatcher.Models.Exceptions;
 
@@ -17,7 +18,7 @@ public static class ReaderService
     /// Parses string-based Scan outputs to an IEnumerable of ScanOutput objects.
     /// </summary>
     /// <returns></returns>
-    private static async Task<IEnumerable<ScanOutput>> ParseScans(IEnumerable<string> RawScans)
+    private static async Task<IEnumerable<ScanOutput>> ParseScans(IEnumerable<string> RawScans, HttpClient Client, UserAgent Agent)
     {
         // check for faulting parses and remove them from the enumerable
         IEnumerable<Task<ScanOutput>> ParseTasks = [];
@@ -26,7 +27,7 @@ public static class ReaderService
             Task<ScanOutput>? Parse;
             try
             {
-                Parse = ScanOutput.ParseCSV(_raw);
+                Parse = ScanOutput.ParseCSV(_raw, Client, Agent);
             }
             catch
             {
@@ -51,7 +52,7 @@ public static class ReaderService
     /// </summary>
     /// <returns>An IEnumerable of Scan results as ScanOutput objects.</returns>
     /// <exception cref="OutputFileAccessException"></exception>
-    public static async Task<IEnumerable<ScanOutput>> ReadNewScans()
+    public static async Task<IEnumerable<ScanOutput>> ReadNewScans(HttpClient Client, UserAgent Agent)
     {
         // attempt to read the Scan Output file and throw an access exception if the read fails
         IEnumerable<string> RawScans;
@@ -70,7 +71,7 @@ public static class ReaderService
             );
         }
         // parse ScanOutput objects from the Raw Scans
-        IEnumerable<ScanOutput> ParsedScans = await ParseScans(RawScans);
+        IEnumerable<ScanOutput> ParsedScans = await ParseScans(RawScans, Client, Agent);
         // clear the file contents and return new Scan outputs
         await File.WriteAllTextAsync(OutputFile, "");
         return ParsedScans;

--- a/LotComWatcher/Program.cs
+++ b/LotComWatcher/Program.cs
@@ -1,3 +1,5 @@
+using LotCom.Database.Auth;
+using LotCom.Database.Http;
 using LotComWatcher;
 
 var builder = Host.CreateApplicationBuilder(args);
@@ -6,6 +8,14 @@ builder.Services.AddWindowsService(options =>
 {
     options.ServiceName = "LotCom Watcher microservice";
 });
+
+// inject an HttpClient for the app
+UserAgent Agent = UserAgentFactory.CreateWatcherAgent(System.Reflection.Assembly.GetEntryAssembly()!.GetName().Version!.ToString());
+builder.Services.AddSingleton(Agent);
+HttpClient Http = HttpClientFactory.Create(Agent);
+builder.Services.AddSingleton(Http);
+
+// inject the Worker service
 builder.Services.AddHostedService<Worker>();
 
 var host = builder.Build();

--- a/LotComWatcher/Worker.cs
+++ b/LotComWatcher/Worker.cs
@@ -18,17 +18,24 @@ public class Worker : BackgroundService
     private readonly ILogger<Worker> Logger;
 
     /// <summary>
-    /// A UserAgent object that can be used to authorize API calls from this object.
+    /// UserAgent used to authenticate API calls in the LotCom system.
     /// </summary>
-    private readonly UserAgent Agent = UserAgentFactory.CreateWatcherAgent(System.Reflection.Assembly.GetEntryAssembly()!.GetName().Version!.ToString());
+    private readonly UserAgent Agent;
+
+    /// <summary>
+    /// HttpClient configured to communicate with the LotCom system.
+    /// </summary>
+    private readonly HttpClient Http;
 
     /// <summary>
     /// Creates a Service Worker that performs the Service's main event/work loop.
     /// </summary>
     /// <param name="Logger"></param>
-    public Worker(ILogger<Worker> Logger)
+    public Worker(ILogger<Worker> Logger, HttpClient Http, UserAgent Agent)
     {
         this.Logger = Logger;
+        this.Http = Http;
+        this.Agent = Agent;
     }
 
     /// <summary>
@@ -77,7 +84,7 @@ public class Worker : BackgroundService
             IEnumerable<Scan>? ScansFromDatabase;
             try
             {
-                ScansFromDatabase = await ScanService.GetAllWithinRange(60, Agent);
+                ScansFromDatabase = await ScanService.GetAllWithinRange(60, Http, Agent);
             }
             // some database-generated issue
             catch (HttpRequestException _ex)
@@ -100,7 +107,7 @@ public class Worker : BackgroundService
                 ScansFromDatabase = ScansFromDatabase
                     .Where(x => x.CompareDateWithinRange(60, DateTime.Now));
                 // read the Scan Output file; confirm parsing did not fail/return null
-                IEnumerable<ScanOutput> Outputs = await ReaderService.ReadNewScans();
+                IEnumerable<ScanOutput> Outputs = await ReaderService.ReadNewScans(Http, Agent);
                 if (!Outputs.Any())
                 {
                     continue;
@@ -126,7 +133,7 @@ public class Worker : BackgroundService
                     bool Created;
                     try
                     {
-                        Created = await ScanService.Create(ScanToCreate, Agent);
+                        Created = await ScanService.Create(ScanToCreate, Http, Agent);
                     }
                     // some database-generated issue
                     catch (HttpRequestException _ex)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# LotCoM-watcher
+# LotCom-watcher
 
-[![CI/CD](https://github.com/LotCoM/LotCom-watcher/actions/workflows/cicd.yml/badge.svg)](https://github.com/LotCoM/LotCom-watcher/actions/workflows/cicd.yml) [![CodeQL](https://github.com/LotCoM/LotCom-watcher/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/LotCoM/LotCom-watcher/actions/workflows/github-code-scanning/codeql)
+[![CI/CD](https://github.com/LotCom/LotCom-watcher/actions/workflows/cicd.yml/badge.svg)](https://github.com/LotCom/LotCom-watcher/actions/workflows/cicd.yml) [![CodeQL](https://github.com/LotCom/LotCom-watcher/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/LotCom/LotCom-watcher/actions/workflows/github-code-scanning/codeql)
 
-[LotCoM](https://github.com/LotCoM) System dedicated `WinService` that processes scan results from YNA's fleet of production floor handheld scanners. Reads, formats, processes, and inserts new Label scans into the LotCoM database.
+[LotCom](https://github.com/LotCom) System dedicated `WinService` that processes scan results from YNA's fleet of production floor handheld scanners. Reads, formats, processes, and inserts new Label scans into the LotCom database.
 
 ### This is a privately-directed project
 
-Please read the [Contribution Guide](https://github.com/LotCoM/LotCoM-watcher/blob/develop/CONTRIBUTING.md) for more information.
+Please read the [Contribution Guide](https://github.com/LotCom/LotCom-watcher/blob/develop/CONTRIBUTING.md) for more information.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-The following versions of LotCoM Watcher are
+The following versions of LotCom Watcher are
 currently being supported with security updates.
 
 | Version | Supported          |
@@ -12,6 +12,6 @@ currently being supported with security updates.
 
 ## Reporting a Vulnerability
 
-If you believe there is a security risk in LotCoM Watcher, please email the developer(s).
+If you believe there is a security risk in LotCom Watcher, please email the developer(s).
 
 masonritchason@gmail.com | ritchasonm@yna.us


### PR DESCRIPTION
# 1.0.21

**Enter a very brief description of the overall purpose of this release.**

Hotfix to address an issue where **LotCom Watcher** creates thousands of `HttpClient` instances and overloads the server's DNS, SSL, and Network Driver.

## Features

**Describe each of the new features being introduced in this release.
Include descriptions and references to resolved Issues/Requests.
List newly implemented APIs or classes.**

- [`feat/1.0.21`](https://github.com/LotCom/LotCom-watcher/pull/36):
  - Integrate with change to `DAL` in **LotCom Libraries** that requires the LotCom apps to provide their own `HttpClient`.
  - Add dependency injection of `HttpClient` and `UserAgent` services.

## Fixes

**Explain each of the major fixes introduced in this release.
Include descriptions and references to resolved Issues/Requests.
List newly implemented APIs or classes.**

## Changes

**List any other changes made in this pull request.
These are changes that are not related to a resolved Issue/Request.**

## Impact

**Discuss any potential impacts this release may have on existing functionalities.**

This hotfix intends to restore intended functionality.

## Checklist

- [X] Code follows the project's coding standards

- [x] SemVer conventions are observed and properly applied

- [x] All references to the Version are bumped

- [x] CHANGELOG.md has been updated to include all changes

- [x] Any other documentation has been updated to reflect the release

## Additional Notes

Any additional information or context relevant to this PR.